### PR TITLE
Add BatchChanger

### DIFF
--- a/contracts/Changers/BatchChanger.sol
+++ b/contracts/Changers/BatchChanger.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.5.0;
+// solium-disable no-experimental
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/ownership/Ownable.sol";
+
+// Adaptation of https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/governance/BatchChanger.sol
+/**
+ * @dev Contract module that groups operations to be run by the Governor in a single transaction
+ */
+contract BatchChanger is Ownable {
+  address[] public targetsToExecute;
+  bytes[] public datasToExecute;
+
+  /**
+   * @dev Emitted when a call is scheduled.
+   */
+  event CallScheduled(address indexed target, bytes data);
+
+  /**
+   * @dev Emitted when a call is performed.
+   */
+  event CallExecuted(address indexed target, bytes data);
+
+  /**
+   * @dev Length of the targetsToExecute array
+   */
+  function targetsToExecuteLength() public view returns(uint) {
+    return targetsToExecute.length;
+  }
+
+  /**
+   * @dev Length of the datasToExecute array
+   */
+  function datasToExecuteLength() public view returns(uint) {
+    return datasToExecute.length;
+  }
+
+  /**
+    * @dev Schedule an operation containing a batch of transactions.
+    *
+    * Emits one {CallScheduled} event per transaction in the batch.
+    *
+    */
+  function schedule(
+    address[] memory targets,
+    bytes[] memory datas
+  ) public onlyOwner {
+    require(targets.length == datas.length, "BatchChanger: length mismatch");
+
+    for (uint256 i = 0; i < targets.length; ++i) {
+      _schedule(targets[i], datas[i]);
+    }
+  }
+
+  /**
+    * @dev Execute an (ready) operation containing a batch of transactions.
+    *
+    * Emits one {CallExecuted} event per transaction in the batch.
+    *
+    * Should be called by the governor, but this contract does not check that explicitly because
+    * it is not its responsability in the current architecture
+    */
+  function execute() public payable {
+    for (uint256 i = 0; i < targetsToExecute.length; ++i) {
+      _call(targetsToExecute[i], datasToExecute[i]);
+    }
+    delete targetsToExecute;
+    delete datasToExecute;
+  }
+
+  /**
+    * @dev Execute an operation's call.
+    *
+    * Emits a {CallExecuted} event.
+    */
+  function _call(
+    address target,
+    bytes memory data
+  ) private {
+    // solium-disable security/no-low-level-calls
+    (bool success, ) = target.call(data);
+    require(success, "BatchChanger: underlying transaction reverted");
+
+    emit CallExecuted(target, data);
+  }
+
+  /**
+   * @dev Schedule an operation containing a single transaction.
+   *
+   * Emits a {CallScheduled} event.
+   *
+   */
+  function _schedule(
+    address target,
+    bytes memory data
+  ) private {
+    targetsToExecute.push(target);
+    datasToExecute.push(data);
+    emit CallScheduled(target, data);
+  }
+
+}

--- a/contracts/Mocks/MockGoverned.sol
+++ b/contracts/Mocks/MockGoverned.sol
@@ -8,6 +8,7 @@ import "../Governance/Governed.sol";
 contract MockGoverned is Governed {
 
   address public protectedParam;
+  uint public protectedParamUint;
 
 
   constructor(address _protectedParam) public {
@@ -17,5 +18,8 @@ contract MockGoverned is Governed {
 
   function setProtectedParam(address newProtectedParam) public onlyAuthorizedChanger {
     protectedParam = newProtectedParam;
+  }
+  function setProtectedParamUint(uint newProtectedParamUint) public onlyAuthorizedChanger {
+    protectedParamUint = newProtectedParamUint;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,6 +120,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@openzeppelin/contracts": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.3.0.tgz",
+      "integrity": "sha512-lf8C3oULQAnsu3OTRP4tP5/ddfil6l65Lg3JQCwAIgc99vZ1jz5qeBoETGGGmczxt+bIyMI06WPP2apC74EZag=="
+    },
     "@resolver-engine/core": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@resolver-engine/core/-/core-0.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "zos-lib": "2.3.1"
   },
   "dependencies": {
+    "@openzeppelin/contracts": "^2.3.0",
     "openzeppelin-eth": "2.1.3",
     "openzeppelin-solidity": "2.3.0",
     "zos": "2.3.1",

--- a/test/BatchChanger.js
+++ b/test/BatchChanger.js
@@ -1,0 +1,89 @@
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const { expectRevert } = require('openzeppelin-test-helpers');
+
+const Governor = artifacts.require('Governor');
+const MockGoverned = artifacts.require('MockGoverned');
+const BatchChanger = artifacts.require('BatchChanger');
+
+chai.use(chaiAsPromised);
+chai.should();
+
+contract('BatchChanger', function([owner, anAddress, anotherAddress]) {
+  describe('WHEN an authorized member tries and executes a change through the governor', function() {
+    it('THEN the change takes effect', async function() {
+      const initialValue = anAddress;
+      const changeValue = anotherAddress;
+      const changeSecondValue = 1234;
+      const governor = await Governor.new();
+      governor.initialize(owner);
+      const mockGoverned = await MockGoverned.new(initialValue);
+      await mockGoverned.initialize(governor.address);
+
+      const batchChangerContract = await BatchChanger.new();
+      const ownerBatch = await batchChangerContract.owner();
+      await expect(owner).to.equal(ownerBatch);
+
+      const targets = [];
+      const datas = [];
+
+      const setFirstParamData = mockGoverned.contract.methods
+        .setProtectedParam(changeValue)
+        .encodeABI();
+      targets.push(mockGoverned.address);
+      datas.push(setFirstParamData);
+
+      const setSecondParamData = mockGoverned.contract.methods
+        .setProtectedParamUint(changeSecondValue)
+        .encodeABI();
+      targets.push(mockGoverned.address);
+      datas.push(setSecondParamData);
+
+      // Save the transactions to be executed as a batch
+      await batchChangerContract.schedule(targets, datas);
+
+      // Execute in a single transaction the batched transactions
+      await governor.executeChange(batchChangerContract.address);
+
+      await expect(await mockGoverned.protectedParam()).to.equal(changeValue);
+      await expect((await mockGoverned.protectedParamUint()).toString()).to.equal(
+        changeSecondValue.toString()
+      );
+
+      await expect((await batchChangerContract.targetsToExecuteLength()).toString()).to.equal('0');
+      await expect((await batchChangerContract.datasToExecuteLength()).toString()).to.equal('0');
+    });
+  });
+
+  describe('WHEN an unauthorized member tries to add a transaction to the batch', function() {
+    it('THEN then rejects the tx', async function() {
+      const initialValue = anAddress;
+      const changeValue = anotherAddress;
+      const governor = await Governor.new();
+      governor.initialize(owner);
+      const mockGoverned = await MockGoverned.new(initialValue);
+      await mockGoverned.initialize(governor.address);
+
+      const batchChangerContract = await BatchChanger.new();
+      const targets = [];
+      const datas = [];
+
+      const setFirstParamData = await mockGoverned.contract.methods
+        .setProtectedParam(changeValue)
+        .encodeABI();
+      targets.push(mockGoverned.address);
+      datas.push(setFirstParamData);
+
+      await expectRevert(
+        batchChangerContract.schedule(targets, datas, { from: anAddress }),
+        'Ownable: caller is not the owner'
+      );
+
+      // await expectRevert.unspecified(
+      //   governor.executeChange(batchChangerContract.address, {
+      //     from: anAddress
+      //   })
+      // );
+    });
+  });
+});


### PR DESCRIPTION
Add a changer that allows to perform batch calls in a single transaction.
This contract is inspired in the Timelock contract from open zepellin
Added @openzeppelin/contracts dependency to have a non upgreadable Ownable.sol